### PR TITLE
fix compiler warnings causing build errors

### DIFF
--- a/brick/event/event_bus.h
+++ b/brick/event/event_bus.h
@@ -53,7 +53,6 @@ class EventBus : public EventObject {
     EventBus* instance = GetInstance();
 
     // Fetch the list of event pairs unique to this event type
-    const char * a = typeid(T).name();
     Registrations* registrations = instance->handlers[typeid(T)];
 
     // Create a new collection instance for this type if it hasn't been created yet

--- a/brick/indicator/app_indicator_icon.h
+++ b/brick/indicator/app_indicator_icon.h
@@ -15,9 +15,9 @@ class AppIndicatorIcon : public BaseIcon {
  public:
   explicit AppIndicatorIcon(std::string icons_dir);
 
-  virtual void SetIcon(IndicatorStatusIcon icon);
-  virtual void SetTooltip(const char* text);
-  virtual void Show();
+  virtual void SetIcon(IndicatorStatusIcon icon) override;
+  virtual void SetTooltip(const char* text) override;
+  virtual void Show() override;
 
   void SetMenu(GtkWidget *menu, GtkWidget *activate_item);
 

--- a/brick/indicator/gtk2_status_icon.h
+++ b/brick/indicator/gtk2_status_icon.h
@@ -13,9 +13,9 @@ class Gtk2StatusIcon : public BaseIcon {
  public:
   explicit Gtk2StatusIcon(std::string icons_dir);
 
-  virtual void SetIcon(IndicatorStatusIcon icon);
-  virtual void SetTooltip(const char* text);
-  virtual void Show();
+  virtual void SetIcon(IndicatorStatusIcon icon) override;
+  virtual void SetTooltip(const char* text) override;
+  virtual void Show() override;
 
   GtkStatusIcon* GetHandler();
 

--- a/brick/notification_manager_linux.cc
+++ b/brick/notification_manager_linux.cc
@@ -27,10 +27,12 @@ namespace {
   const gint kTypeRegular = 0;
   const gint kTypeMessage = 1;
   // See https://developer.gnome.org/notification-spec/#signal-notification-closed
-  const gint kCloseReasonExpire = 1;
-  const gint kCloseReasonDismissed = 2;
-  const gint kCloseReasonProgrammaticaly = 3;
-  const gint kCloseReasonUndefined = 4;
+  enum CloseReason {
+    kCloseReasonExpire = 1,
+    kCloseReasonDismissed = 2,
+    kCloseReasonProgrammaticaly = 3,
+    kCloseReasonUndefined = 4,
+  };
 
   void
   OnCloseNotification(NotifyNotification *notify, NotificationManager *self) {

--- a/libcef_dll/CMakeLists.txt
+++ b/libcef_dll/CMakeLists.txt
@@ -493,3 +493,7 @@ add_library(libcef_dll_wrapper
 
 # Remove the default "lib" prefix from the resulting library.
 set_target_properties(libcef_dll_wrapper PROPERTIES PREFIX "")
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    target_compile_options(libcef_dll_wrapper PRIVATE -Wno-undefined-var-template)
+endif()

--- a/libcef_dll/base/cef_logging.cc
+++ b/libcef_dll/base/cef_logging.cc
@@ -25,7 +25,11 @@ namespace {
 #if defined(OS_POSIX)
 // From base/safe_strerror_posix.cc.
 
-#define USE_HISTORICAL_STRERRO_R (defined(__GLIBC__) || defined(OS_NACL))
+#if defined(__GLIBC__) || defined(OS_NACL)
+#define USE_HISTORICAL_STRERRO_R 1
+#else
+#define USE_HISTORICAL_STRERRO_R 0
+#endif
 
 #if USE_HISTORICAL_STRERRO_R && defined(__GNUC__)
 // GCC will complain about the unused second wrap function unless we tell it

--- a/macros.cmake
+++ b/macros.cmake
@@ -150,6 +150,8 @@ macro(FIND_LINUX_LIBRARIES libraries)
     message(FATAL_ERROR "Failed to find one of these libraries: ${libraries}")
   endif()
 
+  STRING(REGEX REPLACE "(^| )-I" " -isystem " FLL_CFLAGS "${FLL_CFLAGS}")
+
   # Strip leading and trailing whitepspace.
   STRING(STRIP "${FLL_CFLAGS}"  FLL_CFLAGS)
   STRING(STRIP "${FLL_LDFLAGS}" FLL_LDFLAGS)


### PR DESCRIPTION
Fixes #81 (GCC warns about  parentheses in GTK) and also fixes Clang compile